### PR TITLE
Expand follow-mode doc string.

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -5537,7 +5537,13 @@ e.g:
 \(add-hook 'helm-before-initialize-hook
           (lambda () (helm-attrset 'follow 1 helm-source-buffers-list)))
 
-This will enable `helm-follow-mode' automatically in `helm-source-buffers-list'."
+This will enable `helm-follow-mode' automatically in `helm-source-buffers-list'.
+
+`helm-attrset' will only work if the `helm-source' object is already properly initialized.
+Many of the `helm-source' objects are lazily initialized (or set to `nil` at load time),
+so adding these hooks in your `~/.emacs' (or equivalent) will cause helm to error.
+Some `helm-source' objects have initialization functions available you can call first
+(e.g. `helm-occur-init-source') to enable adding the hooks in your `~/.emacs'."
   (interactive "p")
   (with-helm-alive-p
     (with-current-buffer helm-buffer


### PR DESCRIPTION
Do this because it was not clear to me at first why the suggested hooks were not working in my initialization scripts.

Googling eventually led me to #610, and more code reading led me to understand the issue was all about when `helm-source` objects are usefully initialized.

I would like to try and save future hackers that period of similar frustration.
